### PR TITLE
Enable Presentation Download

### DIFF
--- a/mod/nginx/bbb/web.nginx
+++ b/mod/nginx/bbb/web.nginx
@@ -47,7 +47,7 @@
 		}
 
 		location ~ "^/bigbluebutton/presentation/download\/[0-9a-f]+-[0-9]+/[0-9a-f]+-[0-9]+$" {
-			if ($arg_presFilename !~ "^[0-9a-zA-Z]+\.[0-9a-zA-Z]+$") {
+			if ($arg_presFilename !~ "^[0-9a-zA-Z]+-[0-9]+\.[0-9a-zA-Z]+$") {
 				return 404;
 			}
 			proxy_pass         http://core:8090$uri$is_args$args;


### PR DESCRIPTION
Fix filename regular expression for download of presentation
files.

The current regular expression leads to a 404 not found error; a typical URL in my case looks like https://DOMAIN/bigbluebutton/presentation/download/7edcf389f2e94bb6be5cffde818b51a56e7a88d1-1589742763468/2b1b0499ed3320721f636f41fd31c47fd08c578e-1589742784002?presFilename=2b1b0499ed3320721f636f41fd31c47fd08c578e-1589742784002.pdf