### PR TITLE
IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - TURN server included
 - Fully automated HTTPS certificates
 - Runs on almost any major linux distributon (Debian, Ubuntu, CentOS,...)
+- Full IPv6 support
 
 ## Install
 1. Install docker-ce & docker-compose

--- a/docker-compose.coturn.yml
+++ b/docker-compose.coturn.yml
@@ -4,7 +4,7 @@ services:
     image: instrumentisto/coturn:4.5
     restart: unless-stopped
     command:
-      - "--external-ip=${EXTERNAL_IP}"
+      - "--external-ip=${EXTERNAL_IPv4}"
       - "--static-auth-secret=${TURN_SECRET}"
     volumes:
       - ssl_data:/etc/resty-auto-ssl

--- a/docker-compose.coturn.yml
+++ b/docker-compose.coturn.yml
@@ -4,7 +4,8 @@ services:
     image: instrumentisto/coturn:4.5
     restart: unless-stopped
     command:
-      - "--external-ip=${EXTERNAL_IPv4}"
+      - "--external-ip=${EXTERNAL_IPv4}/${EXTERNAL_IPv4}"
+      - "--external-ip=${EXTERNAL_IPv6:-::1}/${EXTERNAL_IPv6:-::1}"
       - "--static-auth-secret=${TURN_SECRET}"
     volumes:
       - ssl_data:/etc/resty-auto-ssl

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -3,14 +3,12 @@ services:
   https_proxy:
     image: valian/docker-nginx-auto-ssl
     restart: unless-stopped
-    ports:
-      - 80:80
-      - 443:443
     volumes:
       - ssl_data:/etc/resty-auto-ssl
+      - ./mod/https/site.conf:/etc/nginx/conf.d/bbb-docker.conf
     environment:
       ALLOWED_DOMAINS: ${DOMAIN}
-      SITES: ${DOMAIN}=10.7.7.1:8080
+    network_mode: host
 
 volumes:
   ssl_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - SYS_RESOURCE
     environment:
       DOMAIN: ${DOMAIN}
-      EXTERNAL_IP: ${EXTERNAL_IP}
+      EXTERNAL_IPv4: ${EXTERNAL_IPv4}
       SIP_IP_ALLOWLIST: ${SIP_IP_ALLOWLIST}
       NETWORK_INTERFACE: ${NETWORK_INTERFACE:-}
     volumes:
@@ -53,11 +53,13 @@ services:
       - ./mod/nginx/bbb:/etc/nginx/bbb
       - ./mod/nginx/bigbluebutton:/etc/nginx/conf.d/default.conf
       - ${DEFAULT_PRESENTATION:-/dev/null}:/etc/nginx/html/default.pdf
-    networks:
-      bbb-net:
-        ipv4_address: 10.7.7.13
+    network_mode: host
     extra_hosts:
       - "host.docker.internal:10.7.7.1"
+      - "core:10.7.7.2"
+      - "etherpad:10.7.7.4"
+      - "webrtc-sfu:10.7.7.10"
+      - "html5:10.7.7.11"
 
   etherpad:
     build: mod/etherpad
@@ -94,7 +96,6 @@ services:
       KMS_STUN_PORT: ${STUN_PORT}
       KMS_MIN_PORT: 24577
       KMS_MAX_PORT: 32768
-      KMS_EXTERNAL_ADDRESS: ${EXTERNAL_IP} 
       KMS_TURN_URL:
       KMS_NETWORK_INTERFACES: ${NETWORK_INTERFACE:-}
     network_mode: host
@@ -113,10 +114,10 @@ services:
       KURENTO_NAME: kurento
       REDIS_HOST: redis
       FREESWITCH_IP: host.docker.internal
-      FREESWITCH_SIP_IP: ${EXTERNAL_IP}
+      FREESWITCH_SIP_IP: ${EXTERNAL_IPv4}
       ESL_IP: host.docker.internal
       LOG_LEVEL: info
-      NODE_CONFIG: '{"kurento":[{"ip":"${EXTERNAL_IP}","url":"ws://kurento:8888/kurento"}]}'
+      NODE_CONFIG: '{"kurento":[{"ip":"${EXTERNAL_IPv4}","url":"ws://kurento:8888/kurento"}]}'
     ports:
       - "127.0.0.1:3008:3008"
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       EXTERNAL_IPv4: ${EXTERNAL_IPv4}
+      EXTERNAL_IPv6: ${EXTERNAL_IPv6}
       SIP_IP_ALLOWLIST: ${SIP_IP_ALLOWLIST}
       NETWORK_INTERFACE: ${NETWORK_INTERFACE:-}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,8 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       EXTERNAL_IPv4: ${EXTERNAL_IPv4}
-      EXTERNAL_IPv6: ${EXTERNAL_IPv6}
-      SIP_IP_ALLOWLIST: ${SIP_IP_ALLOWLIST}
-      NETWORK_INTERFACE: ${NETWORK_INTERFACE:-}
+      EXTERNAL_IPv6: ${EXTERNAL_IPv6:-::1}
+      SIP_IP_ALLOWLIST: ${SIP_IP_ALLOWLIST:-}
     volumes:
       - ./conf/sip_profiles:/etc/freeswitch/sip_profiles/external
       - ./conf/dialplan_public:/etc/freeswitch/dialplan/public_docker

--- a/mod/coturn/turnserver.conf
+++ b/mod/coturn/turnserver.conf
@@ -61,3 +61,11 @@ no-tlsv1_1
 
 # To enable single filename logs you need to enable the simple-log flag
 syslog
+
+
+# Allocate Address Family according 
+# If enabled then TURN server allocates address family according  the TURN 
+# Client <=> Server communication address family.
+# (By default Coturn works according RFC 6156.)
+# !!Warning: Enabling this option breaks RFC6156 section-4.2 (violates use default IPv4)!!
+keep-address-family

--- a/mod/freeswitch/conf/sip_profiles/external-ipv6.xml
+++ b/mod/freeswitch/conf/sip_profiles/external-ipv6.xml
@@ -1,4 +1,0 @@
-<!-- 
-  IPv6 is disabled for now since there a some more configurations needed
-  to make it work beautifully
- -->

--- a/mod/freeswitch/conf/sip_profiles/external-ipv6.xml
+++ b/mod/freeswitch/conf/sip_profiles/external-ipv6.xml
@@ -1,0 +1,113 @@
+<profile name="external-ipv6">
+  <!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
+  <!-- This profile is only for outbound registrations to providers -->
+  <gateways>
+    <X-PRE-PROCESS cmd="include" data="external-ipv6/*.xml"/>
+  </gateways>
+
+  <aliases>
+    <!--
+        <alias name="outbound"/>
+        <alias name="nat"/>
+    -->
+  </aliases>
+
+  <domains>
+    <!--<domain name="all" alias="false" parse="true"/>-->
+  </domains>
+
+  <settings>
+    <param name="debug" value="0"/>
+    <!-- If you want FreeSWITCH to shutdown if this profile fails to load, uncomment the next line. -->
+    <!-- <param name="shutdown-on-fail" value="true"/> -->
+    <param name="sip-trace" value="no"/>
+    <param name="sip-capture" value="no"/>
+    <param name="rfc2833-pt" value="101"/>
+    <!-- RFC 5626 : Send reg-id and sip.instance -->
+    <!--<param name="enable-rfc-5626" value="true"/> -->
+    <param name="sip-port" value="$${external_sip_port}"/>
+    <param name="dialplan" value="XML"/>
+    <param name="context" value="public"/>
+    <param name="dtmf-duration" value="2000"/>
+    <param name="inbound-codec-prefs" value="$${global_codec_prefs}"/>
+    <param name="outbound-codec-prefs" value="$${outbound_codec_prefs}"/>
+    <param name="hold-music" value="$${hold_music}"/>
+    <param name="rtp-timer-name" value="soft"/>
+    <!--<param name="enable-100rel" value="true"/>-->
+    <!--<param name="disable-srv503" value="true"/>-->
+    <!-- This could be set to "passive" -->
+    <param name="local-network-acl" value="localnet.auto"/>
+    <param name="manage-presence" value="false"/>
+
+    <!-- Added for Microsoft Edge support 
+    <param name="apply-candidate-acl" value="wan_v6.auto"/>
+    <param name="apply-candidate-acl" value="rfc1918.auto"/>
+    <param name="apply-candidate-acl" value="any_v6.auto"/>
+    <param name="apply-candidate-acl" value="wan_v4.auto"/>
+    <param name="apply-candidate-acl" value="any_v4.auto"/>
+    -->
+    <param name="apply-candidate-acl" value="deny_private_v6"/>
+
+    <!-- used to share presence info across sofia profiles
+         manage-presence needs to be set to passive on this profile
+         if you want it to behave as if it were the internal profile
+         for presence.
+    -->
+    <!-- Name of the db to use for this profile -->
+    <!--<param name="dbname" value="share_presence"/>-->
+    <!--<param name="presence-hosts" value="$${domain}"/>-->
+    <!--<param name="force-register-domain" value="$${domain}"/>-->
+    <!--all inbound reg will stored in the db using this domain -->
+    <!--<param name="force-register-db-domain" value="$${domain}"/>-->
+    <!-- ************************************************* -->
+
+    <!--<param name="aggressive-nat-detection" value="true"/>-->
+    <param name="inbound-codec-negotiation" value="generous"/>
+    <param name="nonce-ttl" value="60"/>
+    <param name="auth-calls" value="false"/>
+    <param name="inbound-late-negotiation" value="true"/>
+    <param name="inbound-zrtp-passthru" value="true"/> <!-- (also enables late negotiation) -->
+    <!--
+        DO NOT USE HOSTNAMES, ONLY IP ADDRESSES IN THESE SETTINGS!
+    -->
+    <param name="rtp-ip" value="$${external_ip_v6}"/>
+    <param name="sip-ip" value="$${local_ip_v6}"/>
+    <!-- Shouldn't set these on IPv6 -->
+    <!--<param name="ext-rtp-ip" value="auto-nat"/>-->
+    <!--<param name="ext-sip-ip" value="auto-nat"/>-->
+    <param name="rtp-timeout-sec" value="300"/>
+    <param name="rtp-hold-timeout-sec" value="1800"/>
+    <!--<param name="enable-3pcc" value="true"/>-->
+
+    <!-- TLS: disabled by default, set to "true" to enable -->
+    <param name="tls" value="$${external_ssl_enable}"/>
+    <!-- Set to true to not bind on the normal sip-port but only on the TLS port -->
+    <param name="tls-only" value="false"/>
+    <!-- additional bind parameters for TLS -->
+    <param name="tls-bind-params" value="transport=tls"/>
+    <!-- Port to listen on for TLS requests. (5081 will be used if unspecified) -->
+    <param name="tls-sip-port" value="$${external_tls_port}"/>
+    <!-- Location of the agent.pem and cafile.pem ssl certificates (needed for TLS server) -->
+    <!--<param name="tls-cert-dir" value=""/>-->
+    <!-- Optionally set the passphrase password used by openSSL to encrypt/decrypt TLS private key files -->
+    <param name="tls-passphrase" value=""/>
+    <!-- Verify the date on TLS certificates -->
+    <param name="tls-verify-date" value="true"/>
+    <!-- TLS verify policy, when registering/inviting gateways with other servers (outbound) or handling inbound registration/invite requests how should we verify their certificate -->
+    <!-- set to 'in' to only verify incoming connections, 'out' to only verify outgoing connections, 'all' to verify all connections, also 'subjects_in', 'subjects_out' and 'subjects_all' for subject validation. Multiple policies can be split with a '|' pipe -->
+    <param name="tls-verify-policy" value="none"/>
+    <!-- Certificate max verify depth to use for validating peer TLS certificates when the verify policy is not none -->
+    <param name="tls-verify-depth" value="2"/>
+    <!-- If the tls-verify-policy is set to subjects_all or subjects_in this sets which subjects are allowed, multiple subjects can be split with a '|' pipe -->
+    <param name="tls-verify-in-subjects" value=""/>
+    <!-- TLS version ("sslv23" (default), "tlsv1"). NOTE: Phones may not work with TLSv1 -->
+    <param name="tls-version" value="$${sip_tls_version}"/>
+    <param name="ws-binding" value=":5066"/>
+    <param name="wss-binding" value=":7443"/>
+    <param name="rtcp-audio-interval-msec" value="5000"/>
+    <param name="rtcp-video-interval-msec" value="5000"/>
+    <param name="dtmf-type" value="info"/>
+    <param name="liberal-dtmf" value="true"/>
+  </settings>
+</profile>
+

--- a/mod/freeswitch/conf/vars.xml.tmpl
+++ b/mod/freeswitch/conf/vars.xml.tmpl
@@ -60,7 +60,8 @@
   -->
   <X-PRE-PROCESS cmd="set" data="local_ip_v4=10.7.7.1"/>
   <X-PRE-PROCESS cmd="set" data="local_ip_v6=::1"/>
-  <X-PRE-PROCESS cmd="set" data="external_ipv4_v4={{ .Env.EXTERNAL_IPv4 }}"/>
+  <X-PRE-PROCESS cmd="set" data="external_ip_v4={{ .Env.EXTERNAL_IPv4 }}"/>
+  <X-PRE-PROCESS cmd="set" data="external_ip_v6={{ .Env.EXTERNAL_IPv6 }}"/>
   <X-PRE-PROCESS cmd="set" data="domain={{ .Env.DOMAIN }}"/>
   <X-PRE-PROCESS cmd="set" data="domain_name=$${domain}"/>
   <X-PRE-PROCESS cmd="set" data="hold_music=local_stream://moh"/>

--- a/mod/freeswitch/conf/vars.xml.tmpl
+++ b/mod/freeswitch/conf/vars.xml.tmpl
@@ -60,7 +60,7 @@
   -->
   <X-PRE-PROCESS cmd="set" data="local_ip_v4=10.7.7.1"/>
   <X-PRE-PROCESS cmd="set" data="local_ip_v6=::1"/>
-  <X-PRE-PROCESS cmd="set" data="external_ip_v4={{ .Env.EXTERNAL_IP }}"/>
+  <X-PRE-PROCESS cmd="set" data="external_ipv4_v4={{ .Env.EXTERNAL_IPv4 }}"/>
   <X-PRE-PROCESS cmd="set" data="domain={{ .Env.DOMAIN }}"/>
   <X-PRE-PROCESS cmd="set" data="domain_name=$${domain}"/>
   <X-PRE-PROCESS cmd="set" data="hold_music=local_stream://moh"/>
@@ -300,7 +300,7 @@
        If unspecified, the bind_server_ip value is used.
        Used by: sofia.conf.xml dingaling.conf.xml
   -->
-  <X-PRE-PROCESS cmd="set" data="external_rtp_ip={{ .Env.EXTERNAL_IP }}"/>
+  <X-PRE-PROCESS cmd="set" data="external_rtp_ip={{ .Env.EXTERNAL_IPv4 }}"/>
 
   <!-- external_sip_ip
       Used as the public IP address for SDP.
@@ -313,7 +313,7 @@
        If unspecified, the bind_server_ip value is used.
        Used by: sofia.conf.xml dingaling.conf.xml
   -->
-  <X-PRE-PROCESS cmd="set" data="external_sip_ip={{ .Env.EXTERNAL_IP }}"/>
+  <X-PRE-PROCESS cmd="set" data="external_sip_ip={{ .Env.EXTERNAL_IPv4 }}"/>
 
   <!-- unroll-loops
        Used to turn on sip loopback unrolling.

--- a/mod/freeswitch/entrypoint.sh
+++ b/mod/freeswitch/entrypoint.sh
@@ -4,8 +4,8 @@
 iptables -S INPUT | grep "\-\-dport 5060 " | cut -d " " -f 2- | xargs -rL1 iptables -D
 
 # block requests to 5060 (tcp/udp)
-iptables -A INPUT -i "$NETWORK_INTERFACE" -p tcp --dport 5060 -s 0.0.0.0/0 -j REJECT
-iptables -A INPUT -i "$NETWORK_INTERFACE" -p udp --dport 5060 -s 0.0.0.0/0 -j REJECT
+iptables -A INPUT -p tcp --dport 5060 -s 0.0.0.0/0 -j REJECT
+iptables -A INPUT -p udp --dport 5060 -s 0.0.0.0/0 -j REJECT
 
 # allow some IPs 
 IFS=',' read -ra ADDR <<< "$SIP_IP_ALLOWLIST"

--- a/mod/https/site.conf
+++ b/mod/https/site.conf
@@ -1,0 +1,28 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+map $remote_addr $endpoint_addr {
+    "~:"    [::1];
+    default    127.0.0.1;
+}
+
+server {
+  listen 443 ssl http2 default_server;
+  listen [::]:443 ssl http2 default_server;
+  server_name _;
+
+  include resty-server-https.conf;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_pass http://$endpoint_addr:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_cache_bypass $http_upgrade;
+  }
+}

--- a/mod/nginx/bbb/sip.nginx
+++ b/mod/nginx/bbb/sip.nginx
@@ -1,5 +1,5 @@
 location /ws {
-        proxy_pass https://host.docker.internal:7443;
+        proxy_pass https://$freeswitch_addr:7443;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";

--- a/mod/nginx/bigbluebutton
+++ b/mod/nginx/bigbluebutton
@@ -1,7 +1,13 @@
+map $remote_addr $freeswitch_addr {
+    "~:"    [::1];
+    default    127.0.0.1;
+}
+
 server {
-  listen 80 default_server;
+  listen 8080 default_server;
+  listen [::]:8080 default_server;
   server_name _;
-  access_log  /var/log/nginx/bigbluebutton.access.log;
+  access_log /dev/stdout;
 
   # redirect to greenlight
   location = / {

--- a/mod/nginx/bigbluebutton
+++ b/mod/nginx/bigbluebutton
@@ -1,6 +1,6 @@
 map $remote_addr $freeswitch_addr {
     "~:"    [::1];
-    default    127.0.0.1;
+    default    10.7.7.1;
 }
 
 server {

--- a/mod/nginx/bigbluebutton
+++ b/mod/nginx/bigbluebutton
@@ -8,7 +8,8 @@ server {
   listen [::]:8080 default_server;
   server_name _;
   access_log /dev/stdout;
-
+  absolute_redirect off;
+  
   # redirect to greenlight
   location = / {
       return 302 /b;

--- a/sample.env
+++ b/sample.env
@@ -33,6 +33,7 @@ RAILS_SECRET=cdfbae48b197805a435ab7881da31c642ac1a7d4d5c006441efa8125ae63865ce7c
 DOMAIN=bbb.example.com
 
 EXTERNAL_IPv4=144.76.97.10
+EXTERNAL_IPv6=
 
 # setting the network interface speeds up kurentos WebRTC connection time,
 # but currently also disables IPv6 for Kurento

--- a/sample.env
+++ b/sample.env
@@ -32,9 +32,11 @@ RAILS_SECRET=cdfbae48b197805a435ab7881da31c642ac1a7d4d5c006441efa8125ae63865ce7c
 
 DOMAIN=bbb.example.com
 
-EXTERNAL_IP=144.76.97.10
+EXTERNAL_IPv4=144.76.97.10
 
-# setting the network interface speeds up kurentos WebRTC connection time
+# setting the network interface speeds up kurentos WebRTC connection time,
+# but currently also disables IPv6 for Kurento
+# (https://github.com/Kurento/bugtracker/issues/500)
 #NETWORK_INTERFACE=ens3
 
 # STUN SERVER

--- a/scripts/setup
+++ b/scripts/setup
@@ -19,7 +19,7 @@ then
 fi
 
 
-EXTERNAL_IP=$(curl -s http://whatismyip.akamai.com)
+EXTERNAL_IPv4=$(curl -4 -s https://icanhazip.com)
 
 greenlight=""
 while [[ ! $greenlight =~ ^(y|n)$ ]]; do
@@ -46,8 +46,16 @@ done
 
 ip_correct=""
 while [[ ! $ip_correct =~ ^(y|n)$ ]]; do
-    read -p "Is $EXTERNAL_IP your external IPv4 address? (y/n): " ip_correct
+    read -p "Is $EXTERNAL_IPv4 your external IPv4 address? (y/n): " ip_correct
 done
+
+if [ ! "$ip_correct" == "y" ]
+then
+    EXTERNAL_IPv4=""
+    while [[ ! $EXTERNAL_IPv4 =~ ^[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}$ ]]; do
+        read -p "Please enter correct IPv4 address: " EXTERNAL_IPv4
+    done
+fi
 
 if [ ! "$ip_correct" == "y" ]
 then
@@ -61,7 +69,7 @@ fi
 
 # write settings
 cp sample.env .env
-sed -i "s/EXTERNAL_IP=.*/EXTERNAL_IP=$EXTERNAL_IP/" .env
+sed -i "s/EXTERNAL_IPv4=.*/EXTERNAL_IPv4=$EXTERNAL_IPv4/" .env
 sed -i "s/DOMAIN=.*/DOMAIN=$DOMAIN/" .env
 
 if [ ! "$greenlight" == "y" ]
@@ -79,7 +87,7 @@ then
     sed -i "s/.*TURN_SERVER=.*/TURN_SERVER=turns:$DOMAIN:465?transport=tcp/" .env
     TURN_SECRET=$(head /dev/urandom | tr -dc A-Za-f0-9 | head -c 32)
     sed -i "s/.*TURN_SECRET=.*/TURN_SECRET=$TURN_SECRET/" .env
-    sed -i "s/.*STUN_IP=.*/STUN_IP=$EXTERNAL_IP/" .env
+    sed -i "s/.*STUN_IP=.*/STUN_IP=$EXTERNAL_IPv4/" .env
 else
     sed -i "s/ENABLE_COTURN.*/#ENABLE_COTURN=true/" .env
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -20,6 +20,7 @@ fi
 
 
 EXTERNAL_IPv4=$(curl -4 -s https://icanhazip.com)
+EXTERNAL_IPv6=$(curl -6 -s https://icanhazip.com || true)
 
 greenlight=""
 while [[ ! $greenlight =~ ^(y|n)$ ]]; do
@@ -57,12 +58,20 @@ then
     done
 fi
 
-if [ ! "$ip_correct" == "y" ]
+if [ -n "$EXTERNAL_IPv6" ]
 then
-    EXTERNAL_IP=""
-    while [[ ! $EXTERNAL_IP =~ ^[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}$ ]]; do
-        read -p "Please enter correct IPv4 address: " EXTERNAL_IP
+    ip_correct=""
+    while [[ ! $ip_correct =~ ^(y|n)$ ]]; do
+        read -p "Is $EXTERNAL_IPv6 your external IPv6 address? (y/n): " ip_correct
     done
+
+    if [ ! "$ip_correct" == "y" ]
+    then
+        EXTERNAL_IPv6=""
+        while [[ ! $EXTERNAL_IPv6 =~ ^[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}\.[1-9][0-9]{0,2}$ ]]; do
+            read -p "Please enter correct IPv6 address: " EXTERNAL_IPv6
+        done
+    fi
 fi
 
 
@@ -70,6 +79,7 @@ fi
 # write settings
 cp sample.env .env
 sed -i "s/EXTERNAL_IPv4=.*/EXTERNAL_IPv4=$EXTERNAL_IPv4/" .env
+sed -i "s/EXTERNAL_IPv6=.*/EXTERNAL_IPv6=$EXTERNAL_IPv6/" .env
 sed -i "s/DOMAIN=.*/DOMAIN=$DOMAIN/" .env
 
 if [ ! "$greenlight" == "y" ]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,6 +31,7 @@ else
     # rebuild everything else only when modified
     ./scripts/compose build --pull
 
+    sed -i 's/EXTERNAL_IP=/EXTERNAL_IPv4=/' .env
 
     COMMIT_HASH=$(git rev-parse --short HEAD)
     BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
closes #24 

quite handy for testing this branch with firefox
- `media.peerconnection.ice.relay_only`: force use of TURN server
- `network.dns.disableIPv6` disable IPv6 DNS