### PR TITLE
sip_profiles: add extension field

### DIFF
--- a/conf/sip_profiles/example.xml
+++ b/conf/sip_profiles/example.xml
@@ -6,6 +6,7 @@
     <param name="proxy" value="sipgate.de"/>
     <param name="username" value="USERNAME"/>
     <param name="password" value="PASSWORD"/>
+    <param name="extension" value="EXTERNALDID"/>
   </gateway>
 </include>
 -->


### PR DESCRIPTION
In order to process a phonecall correctly freeswitch requires the extension field in the sip_profiles file. The Value has to be set to the phonenumber given to you by sipgate / your provider.
See https://github.com/bigbluebutton/bigbluebutton.github.io/blob/master/_posts/2019-02-14-customize.md#add-a-phone-number-to-the-conference-bridge for reference.