### PR TITLE
Asks about Prometheus installation when setting up environment vars

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -40,6 +40,11 @@ then
     done
 fi
 
+prometheus_exporter=""
+while [[ ! $prometheus_exporter =~ ^(y|n)$ ]]; do
+    read -p "Should a Prometheus exporter be included? (y/n): " prometheus_exporter
+done
+
 DOMAIN=""
 while [[ -z "$DOMAIN" ]]; do
     read -p "Please enter the domain name: " DOMAIN
@@ -117,6 +122,11 @@ then
     sed -i "s/.*STUN_IP=.*/STUN_IP=$EXTERNAL_IPv4/" .env
 else
     sed -i "s/ENABLE_COTURN.*/#ENABLE_COTURN=true/" .env
+fi
+
+if [ "$prometheus_exporter" == "y" ]
+then
+    sed -i "s/#ENABLE_PROMETHEUS_EXPORTER.*/ENABLE_PROMETHEUS_EXPORTER=true/" .env
 fi
 
 # change secrets


### PR DESCRIPTION
This pr updates `scripts/setup` file by adding a missing step which asks if the user wants a Prometheus exporter container to be added