### PR TITLE
fixed recordings container restart setting

### DIFF
--- a/docker-compose.recordings.yml
+++ b/docker-compose.recordings.yml
@@ -2,6 +2,7 @@ version: '3.6'
 services:
   recordings:
     build: mod/recordings
+    restart: unless-stopped
     depends_on:
       - redis
     environment:


### PR DESCRIPTION
added the `restart: unless-stopped` to `docker-compose.recordings.yml` since the container crashed sometimes and was not restarted automatically